### PR TITLE
Migrate ros1 dependencies to ros2

### DIFF
--- a/car_simulator/package.xml
+++ b/car_simulator/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>car_simulator</name>
   <version>0.0.0</version>
   <description>The car_simulator package</description>
@@ -48,14 +48,16 @@
   <!--   <test_depend>gtest</test_depend> -->
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
-  <exec_depend>rviz</exec_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  
+  <exec_depend>rviz2</exec_depend>
   <exec_depend>gazebo_ros_pkgs</exec_depend>
-  <exec_depend>gazebo_ros_control</exec_depend>
+  <exec_depend>gazebo_ros2_control</exec_depend>
   <exec_depend>velocity_controllers</exec_depend>
   <exec_depend>effort_controllers</exec_depend>
   <exec_depend>position_controllers</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
-  <exec_depend>joint_state_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>
@@ -65,12 +67,11 @@
   <exec_depend>realsense2_camera</exec_depend>
   <exec_depend>realsense2_description</exec_depend>
   <exec_depend>teleop_twist_keyboard</exec_depend>
-  <buildtool_depend>catkin</buildtool_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->
-
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/example_node/package.xml
+++ b/example_node/package.xml
@@ -5,8 +5,8 @@
   <maintainer email="hifzhil12@gmail.com"></maintainer>
   <license>TODO</license>
   <author email="hifzhil12@gmail.com"></author>
-  <buildtool_depend>catkin</buildtool_depend>
-  <depend>roscpp</depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>nav_msgs</depend>
@@ -14,14 +14,16 @@
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
   <depend>controller_manager</depend>
-  <depend>joint_state_controller</depend>
+  <depend>joint_state_broadcaster</depend>
   <depend>robot_state_publisher</depend>
-  <depend>hector_gazebo_plugins</depend>
+  <depend>gazebo_plugins</depend>
   <build_depend>libpcl-all-dev</build_depend>
   <build_depend>car_msgs</build_depend>
   
   <!-- <build_depend>message_generation</build_depend>
   <exec_depend>message_runtime</exec_depend> -->
   <exec_depend>libpcl-all</exec_depend>
-  <export></export>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/gps_sensor_kf/package.xml
+++ b/gps_sensor_kf/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>gps_sensor_kf</name>
   <version>0.0.0</version>
   <description>The gps_sensor_kf package</description>
@@ -48,15 +48,13 @@
   <!--   <test_depend>gtest</test_depend> -->
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>rospy</build_depend>
-  <build_export_depend>rospy</build_export_depend>
-  <exec_depend>rospy</exec_depend>
+  <buildtool_depend>ament_python</buildtool_depend>
+  <depend>rclpy</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->
-
+    <build_type>ament_python</build_type>
   </export>
 </package>

--- a/msgs/package.xml
+++ b/msgs/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>car_msgs</name>
   <version>2.2.0</version>
   <description>Messages to control the StreetDrone</description>
@@ -9,12 +9,18 @@
 
   <license>Apache 2</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
+  <build_depend>rosidl_default_generators</build_depend>
 
-  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <depend>std_msgs</depend>
+  
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 
 </package>

--- a/plugins/car_vehicle_interface/package.xml
+++ b/plugins/car_vehicle_interface/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>car_bridge</name>
   <version>0.0.0</version>
   <description>The car_vehicle_interface package</description>
@@ -7,21 +7,21 @@
   <maintainer email="focc@todo.todo">focc</maintainer>
 
   <license>TODO</license>
-  <depend>nodelet</depend>
   <depend>car_msgs</depend>
   <depend>pluginlib</depend>
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
+  <depend>rclcpp_components</depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>rclcpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>rclcpp</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <nodelet plugin="${prefix}/nodelet_plugins.xml"/>
+    <build_type>ament_cmake</build_type>
   </export>
 
 </package>

--- a/spawn_car/package.xml
+++ b/spawn_car/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>spawn_car</name>
   <version>0.0.0</version>
   <description>The spawn_car package</description>
@@ -48,19 +48,19 @@
   <!--   <test_depend>gtest</test_depend> -->
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rclpy</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>gazebo_ros</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>rclcpp</build_export_depend>
+  <build_export_depend>rclpy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
   <build_export_depend>gazebo_ros</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>rospy</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>gazebo_ros</exec_depend>
@@ -69,6 +69,7 @@
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->
+    <build_type>ament_cmake</build_type>
     <gazebo_ros
       gazebo_model_path="${prefix}/.."
     />


### PR DESCRIPTION
Convert all `package.xml` files from ROS1 to ROS2 format by updating dependencies and build tools.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f914543-1d67-49cf-97cf-42d8a3e949a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f914543-1d67-49cf-97cf-42d8a3e949a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>